### PR TITLE
Add flake8, lint target and lint project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ venv:
 clean:
 	rm -rf dist build kyber.egg-info
 
-test:
+lint:
+	venv/bin/flake8 kyber
+	venv/bin/flake8 tests
+
+test: lint
 	venv/bin/py.test tests/ -vsx --pdb
 
 release:

--- a/kyber/__init__.py
+++ b/kyber/__init__.py
@@ -1,6 +1,7 @@
 import click
 import os
 import pkgutil
+import sys
 from dulwich import porcelain as git
 from jinja2 import Template
 
@@ -110,7 +111,7 @@ def config_list():
 def config_get(key):
     env = Environment(context.name)
     cfg = env.secret
-    if not key in cfg:
+    if key not in cfg:
         click.echo("No var found for `{}.{}`".format(context.name, key))
         return
     click.echo(cfg[key])
@@ -134,7 +135,7 @@ def config_unset(key):
     env = Environment(context.name)
     cfg = env.secret
     if click.confirm(u"Do you wish to delete config variable {}.{} with value of `{}`".format(
-        context.name, key, cfg[key])):
+            context.name, key, cfg[key])):
         del cfg[key]
         cfg.update()
 

--- a/kyber/config.py
+++ b/kyber/config.py
@@ -1,6 +1,7 @@
 import click
 import os
 
+
 def write_envdir(cfg, target_dir):
     for param in sorted(cfg.keys()):
         with open(os.path.join(target_dir, param), "w") as out:

--- a/kyber/context.py
+++ b/kyber/context.py
@@ -44,7 +44,6 @@ class Context(object):
         for task in checks:
             tasks[task]()
 
-
     def load_config(self):
         cfg_name = os.path.join(self.cwd, '.kyber/config')
         try:
@@ -60,7 +59,8 @@ class Context(object):
         from kyber.lib.kube import kube_api
         kube_ctx = kube_api.config.current_context
         if kube_ctx not in cfg:
-            raise ContextError("No configuration found for kube context `{}` in kyber context.  Forgot to run 'kb init'?".format(kube_ctx))
+            raise ContextError(("No configuration found for kube context `{}` in kyber context."
+                                " Forgot to run 'kb init'?").format(kube_ctx))
 
         self.name = cfg[kube_ctx]['name']
         self.docker = cfg[kube_ctx]['docker']

--- a/kyber/deploy.py
+++ b/kyber/deploy.py
@@ -1,11 +1,9 @@
 """ kyber.deploy - logic and cli commands related to deploying a kyber project.
 """
 import click
-import json
-import pykube
 import time
 
-from .objects import App, Deployment, Environment
+from .objects import Deployment, Environment
 from .lib.kube import kube_api
 
 

--- a/kyber/init.py
+++ b/kyber/init.py
@@ -1,12 +1,8 @@
 import click
 import os
-import sys
 import yaml
-from dulwich import porcelain as git
-from jinja2 import Template
-from pykube.objects import Secret, Service
 
-from kyber.objects import App, Deployment, Environment
+from kyber.objects import App, Environment
 from kyber.lib.kube import kube_api
 
 
@@ -62,7 +58,7 @@ def get_default_name(repo):
         origin = repo.get_config()[('remote', 'origin')]['url']
         dotgit = origin.split('/')[-1]
         return dotgit.replace('.git', '')
-    except KeyError, IndexError:
+    except (KeyError, IndexError):
         pass
 
     # 2. use repo directory path
@@ -73,7 +69,8 @@ def get_default_name(repo):
 
 
 def from_scratch(name, tag):
-    docker = click.prompt("Enter ECR (e.g. ...dkr.ecr.us-east-1.amazonaws.com/{})".format(name), default=os.environ.get('ECR'))
+    docker = click.prompt(
+        "Enter ECR (e.g. ...dkr.ecr.us-east-1.amazonaws.com/{})".format(name), default=os.environ.get('ECR'))
     port = click.prompt("Enter app port", default=5000)
     tag = click.prompt("Enter tag", default='git_{}'.format(tag))
     dns_name = click.prompt("Enter DNS name (enter for none)", default=None)

--- a/kyber/lib/ecr.py
+++ b/kyber/lib/ecr.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 from boto3.session import Session

--- a/kyber/objects/secret.py
+++ b/kyber/objects/secret.py
@@ -41,7 +41,7 @@ class Secret(pykube.Secret):
         return unicode(repr(self))
 
     def has_key(self, k):
-        return k in self.obj['data']
+        return self.obj['data'].has_key(k)  # noqa
 
     def keys(self):
         return self.obj['data'].keys()
@@ -55,8 +55,8 @@ class Secret(pykube.Secret):
     def iteritems(self):
         return self.obj['data'].iteritems()
 
-    def pop(self, *args):
-        return self.obj['data'].pop(*args)
+    def pop(self, *args, **kwargs):
+        return self.obj['data'].pop(*args, **kwargs)
 
     def update(self):
         """ Overload the pykube .update because it uses PATCH, while we

--- a/kyber/objects/secret.py
+++ b/kyber/objects/secret.py
@@ -41,10 +41,7 @@ class Secret(pykube.Secret):
         return unicode(repr(self))
 
     def has_key(self, k):
-        return self.obj['data'].has_key(k)
-
-    def pop(self, k, d=None):
-        return self.obj['data'].pop(k, d)
+        return k in self.obj['data']
 
     def keys(self):
         return self.obj['data'].keys()

--- a/kyber/shell.py
+++ b/kyber/shell.py
@@ -13,11 +13,10 @@ def get_kubectl_path():
 
 
 def run(name):
-    ready = False
     for pod in Pod.objects(kube_api).filter(selector={'app': 'takumi-server'}).iterator():
         if pod.ready:  # use the first ready pod, otherwise we use the last pod
             break
 
     click.echo("Running shell in pod `{}` in kube ctx `{}`".format(
-       pod.name, kube_api.config.current_context))
+               pod.name, kube_api.config.current_context))
     os.execve(get_kubectl_path(), ["kubectl", "exec", "-i", "-t", pod.name, "/bin/bash"], os.environ)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E128,E712,E172,E241,E731
+max-line-length = 120
+max-complexity = 10

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 mock==2.0.0
 pdbpp==0.8.3
 pytest==3.0.6
+flake8==3.3.0

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,6 +1,7 @@
 from kyber.objects.environment import kube_from_template
 from kyber.objects import App
 
+
 def test_kube_from_template():
     app = App('test-app', 'ecr.testing.test/test-app', 'git_test', 31337)
     secret = kube_from_template('secret', app)


### PR DESCRIPTION
Added flake8 and linted the project. Mainly it was unused imports or variables, but in some cases actual errors (`sys` wasn't imported in `kyber/__init__.py` and in `kyber/init.py` there was a catch block missing parenthesis around multiple exceptions to catch).

I don't believe any of the unused imports were required, though you might be able to correct me if I'm wrong. Tests still run, but I would like to be able to do a quick smoke test with a local dev kyber. How would I go ahead with installing this locally and globally to test? If not globally, what's the correct way to setup to try it out?