### PR TITLE
Adding 'dash' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,13 @@ can be changed/disabled with `kubectl edit deployment {app name}`.
 - [status](#status)
 - [shell](#shell)
 - [completion](#completion)
+- [dash](#dash)
 
 ## init
 
 ### Initialize a project
 
-    (kb: dev) my-project (master) $ kb init
+    (kb: dev) my-project $ kb init
 
 Init checks to see if you have a local (copied) `.kyber/config` file which it
 can use to initialize the project against this kubernetes context, if a matching
@@ -79,7 +80,7 @@ file entry.
 
 ### Deploy another container to a project
 
-    (kb: dev) my-project (master) $ kb deploy [<tag defaults to tip of current branch>]
+    (kb: dev) my-project $ kb deploy [<tag defaults to tip of current branch>]
     ...
 
 
@@ -92,7 +93,7 @@ and unsetting individual values.
 
 ### list
 
-    (kb: dev) my-project (master) $ kb config list
+    (kb: dev) my-project $ kb config list
     SOME=variables
     ARE=more
     EQUAL=than
@@ -100,22 +101,22 @@ and unsetting individual values.
 
 ### get
 
-    (kb: dev) my-project (master) $ kb config get<TAB>
+    (kb: dev) my-project $ kb config get<TAB>
     ARE SOME EQUAL OTHERS
-    (kb: dev) my-project (master) $ kb config get ARE
+    (kb: dev) my-project $ kb config get ARE
     more
 
 ### set
 
-    (kb: dev) my-project (master) $ kb config set OTHERS 99%
-    (kb: dev) my-project (master) $ kb config get OTHERS
+    (kb: dev) my-project $ kb config set OTHERS 99%
+    (kb: dev) my-project $ kb config get OTHERS
     99%
 
 ### unset
 
-    (kb: dev) my-project (master) $ kb config unset OTHERS
+    (kb: dev) my-project $ kb config unset OTHERS
     Do you wish to delete config variable my-project.OTHERS with value of `99%` [y/N]:
-    (kb: dev) my-project (master) $ kb config get OTHERS
+    (kb: dev) my-project $ kb config get OTHERS
     No var found for `my-project.OTHERS`
 
 ### envdir
@@ -143,7 +144,7 @@ See the current kyber status of a project, most importantly the deployed tag,
 the docker registry/repo, and whether the tip of the current master is deployable
 (is there a docker named `{app.docker:git_{git.head()}}` in the ECR.
 
-    (kb: dev) my-project (master) $ kb status
+    (kb: dev) my-project $ kb status
     Project: my-project
     Docker: 12345.dkr.ecr.us-east-1.amazonaws.com/takumi-server
     Deployed tag: git_6eea5482b7f55823f86a63d9ddf6d84ec6769a78
@@ -155,9 +156,31 @@ Execute `/bin/bash` inside one of the pods in your app, useful for debugging.
 Will choose the first ready pod, or the last one returned if none are ready.
 Ready here refers to the kubernetes definition (liveness/readiness).
 
-    (kb: dev) my-project (master) $ kb shell
+    (kb: dev) my-project $ kb shell
     Running shell in pod `my-project-...` in kubectx `dev`
     root@bcd23f231d09:~#
+
+## dash
+
+Opens up the kubernetes-dashboard on the service object for the kyber app
+in the current context, or if called from outside a kyber context, it will
+open the pods dashboard for the current kubectl context.
+
+    (kb: dev) my-project $ kb dash
+    Opening dashboard for `my-project` in `dev`
+
+    (kb: dev) ~ $ kb dash
+    Not in a kyber context, showing dash for k8s pods in `dev`
+
+
+`dash` tries to use the command line program `open` which works on OS X, but
+on most linux distributions this will probably fail (`xdg-open` might be an
+alternative to look for and try).  If dash fails to find the `open` executable
+it will report back and print out the URL:
+
+    (kb: dev) my-project $ kb dash
+    Unable to launch dashboard automatically (Can't find 'open' executable, is it in your $PATH?)
+    URL: https://admin:***@api.kube-dev.you.org/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/#/service/dev/my-project?namespace=dev
 
 ## completion
 

--- a/kyber/__init__.py
+++ b/kyber/__init__.py
@@ -6,6 +6,7 @@ from dulwich import porcelain as git
 from jinja2 import Template
 
 # logical modules
+import dash
 import deploy
 import config
 import context
@@ -94,6 +95,12 @@ def get_completion(ctx):
 @context.required()
 def run_shell():
     shell.run(context.name)
+
+
+@cli.command('dash')
+def open_dashboard():
+    """ Launch the kube-dashboard to see the pods running in the current kube context """
+    dash.launch()
 
 
 @config_cli.command('list')

--- a/kyber/context.py
+++ b/kyber/context.py
@@ -112,4 +112,4 @@ def required(**ctx_kwargs):
     return wrapper
 
 
-__all__ = [required, name, docker, tag, target, dirty, dirty_reason]
+__all__ = [required, name, docker, tag, target, dirty, dirty_reason, Context]

--- a/kyber/dash.py
+++ b/kyber/dash.py
@@ -1,0 +1,52 @@
+import click
+import os
+from urlparse import urlparse, urlunparse
+
+from kyber.context import Context, ContextError
+from kyber.utils import get_executable_path
+
+
+def _kube_dash_base_url(cfg):
+    url = urlparse(cfg.cluster['server'])
+    try:
+        username = cfg.user['username']
+        password = cfg.user['password']
+        url = url._replace(netloc='{}:{}@{}'.format(username, password, url.netloc))
+    except KeyError:  # no username/pass in kube context?
+        pass
+    return url
+
+
+def service_dashboard(cfg, name):
+    path = ("/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/"
+            "#/service/{namespace}/{app_name}?namespace={namespace}").format(
+                namespace=cfg.namespace, app_name=name)
+    return urlunparse(_kube_dash_base_url(cfg)._replace(path=path))
+
+
+def namespace_dashboard(cfg):
+    path = ("/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/"
+            "#/pod?namespace={namespace}").format(namespace=cfg.namespace)
+    return urlunparse(_kube_dash_base_url(cfg)._replace(path=path))
+
+
+def launch(cfg=None, executor=None):
+    if cfg is None:
+        from kyber.lib.kube import kube_api
+        cfg = kube_api.config
+    if executor is None:
+        executor = os.execve
+
+    try:
+        context = Context()
+        click.echo("Opening dashboard for `{}` in `{}`".format(context.name, cfg.namespace))
+        url = service_dashboard(cfg, context.name)
+    except ContextError:  # fall back to opening the kubernetes dashboard
+        click.echo("Not in a kyber context, showing dash for k8s pods in `{}`".format(cfg.namespace))
+        url = namespace_dashboard(cfg)
+
+    try:
+        executor(get_executable_path('open'), ["open", url], os.environ)
+    except Exception as e:
+        click.echo("Unable to launch dashboard automatically ({})".format(e.message))
+        click.echo("URL: {}".format(url))

--- a/kyber/shell.py
+++ b/kyber/shell.py
@@ -1,15 +1,8 @@
 import click
 import os
-import sh
 from pykube.objects import Pod
 from kyber.lib.kube import kube_api
-
-
-def get_kubectl_path():
-    path = sh.which('kubectl')
-    if path is None:
-        raise Exception("Can't find kubectl executable, is it in your $PATH?")
-    return str(path)
+from kyber.utils import get_executable_path
 
 
 def run(name):
@@ -19,4 +12,4 @@ def run(name):
 
     click.echo("Running shell in pod `{}` in kube ctx `{}`".format(
                pod.name, kube_api.config.current_context))
-    os.execve(get_kubectl_path(), ["kubectl", "exec", "-i", "-t", pod.name, "/bin/bash"], os.environ)
+    os.execve(get_executable_path('kubectl'), ["kubectl", "exec", "-i", "-t", pod.name, "/bin/bash"], os.environ)

--- a/kyber/utils.py
+++ b/kyber/utils.py
@@ -1,3 +1,4 @@
+import sh
 import time
 
 
@@ -28,3 +29,10 @@ class TimeIt(object):
     def __exit__(self, *args, **kwargs):
         self.end_t = time.time()
         print "{}: took {}s".format(self.name, self.end_t - self.start_t)
+
+
+def get_executable_path(executable):
+    path = sh.which(executable)
+    if path is None:
+        raise Exception("Can't find '{}' executable, is it in your $PATH?".format(executable))
+    return str(path)

--- a/tests/test_dash.py
+++ b/tests/test_dash.py
@@ -1,0 +1,50 @@
+import mock
+from collections import namedtuple
+
+from kyber.context import ContextError
+from kyber.dash import launch, _kube_dash_base_url
+
+
+KubeConfig = namedtuple('KubeConfig', 'cluster user')
+
+
+def test_kube_dash_base_url_adds_auth_if_found():
+    cfg = KubeConfig(cluster=dict(server='https://test'), user=dict(username='mocky', password='python'))
+    url = _kube_dash_base_url(cfg)
+    assert url.netloc == 'mocky:python@test'
+
+
+def test_kube_dash_base_url_adds_no_auth_if_not_found():
+    cfg = KubeConfig(cluster=dict(server='https://test'), user=dict())
+    url = _kube_dash_base_url(cfg)
+    assert url.netloc == 'test'
+
+
+def test_launch_calls_service_dashboard():
+    with mock.patch('kyber.dash.Context'):
+        with mock.patch('kyber.dash.service_dashboard') as mock_service_dashboard:
+            launch(cfg=mock.Mock(), executor=mock.Mock())
+            assert mock_service_dashboard.called
+
+
+def test_launch_calls_namespace_dashboard_if_context_error():
+    with mock.patch('kyber.dash.Context') as mock_context:
+        mock_context.side_effect = ContextError('meh')
+        with mock.patch('kyber.dash.service_dashboard') as mock_service_dashboard:
+            with mock.patch('kyber.dash.namespace_dashboard') as mock_namespace_dashboard:
+                launch(cfg=mock.Mock(), executor=mock.Mock())
+                assert not mock_service_dashboard.called
+                assert mock_namespace_dashboard.called
+
+
+def test_launch_echos_url_if_executor_not_found():
+    with mock.patch('kyber.dash.Context'):
+        with mock.patch('kyber.dash.service_dashboard'):
+            with mock.patch('kyber.dash.namespace_dashboard'):
+                with mock.patch('kyber.dash.click') as mock_click:
+                    mock_exec = mock.Mock(side_effect=Exception('mocky pythons holy exception'))
+                    launch(cfg=mock.Mock(), executor=mock_exec)
+                    assert mock_exec.called
+                    assert mock_click.echo.called
+                    assert 'mocky pythons holy exception' in mock_click.echo.call_args_list[1][0][0]
+                    assert 'URL: ' in mock_click.echo.call_args_list[2][0][0]


### PR DESCRIPTION
This PR adds the 'dash' command to easily open up the kubernetes dashboard for the given kubectl context, and if available the kyber context.  If in a kyber context it will try to open up the service dashboard.