### PR TITLE
Make PS1 variable parts more dynamic

### DIFF
--- a/kyber/templates/kyber-completion.sh
+++ b/kyber/templates/kyber-completion.sh
@@ -19,8 +19,7 @@ function __list_kube_contexts {
 }
 
 function kubes {
-	# a helper function to list kube contexts, which caches the output for
-	# 10 minutes
+	# a helper function to list kube contexts, which caches the output for 1 minute
 	rm -f `find $_CURRENT_KUBE_CONTEXT_FILE -type file -mtime +0h1m 2>/dev/null`
 	if [ ! -e $_CURRENT_KUBE_CONTEXT_FILE ]; then
 		__list_kube_contexts > $_CURRENT_KUBE_CONTEXT_FILE

--- a/kyber/templates/kyber-completion.sh
+++ b/kyber/templates/kyber-completion.sh
@@ -1,5 +1,6 @@
 GREP_BIN=$(/usr/bin/which grep)
 ORIGINAL_PS1=$PS1
+_CURRENT_KUBE_CONTEXT_FILE=/tmp/kubectl-config-get-contexts.tmp
 
 function __kube_check {
 	kubectl > /dev/null 2>&1
@@ -16,10 +17,36 @@ function __kube_guard {
 function __list_kube_contexts {
 	kubectl config get-contexts
 }
-alias kubes=__list_kube_contexts
+
+function kubes {
+	# a helper function to list kube contexts, which caches the output for
+	# 10 minutes
+	rm -f `find $_CURRENT_KUBE_CONTEXT_FILE -type file -mtime +0h1m 2>/dev/null`
+	if [ ! -e $_CURRENT_KUBE_CONTEXT_FILE ]; then
+		__list_kube_contexts > $_CURRENT_KUBE_CONTEXT_FILE
+	fi
+	cat $_CURRENT_KUBE_CONTEXT_FILE
+}
+
+# PS1 helpers
+function __get_current_kube_context_namespace {
+	kubes|$GREP_BIN '^*'|awk {'print $5'}
+}
+
+function __get_current_kube_context_cluster {
+        kubes|$GREP_BIN '^*'|awk {'print $3'}
+}
+
+function __get_current_kube_context_auth {
+	kubes|$GREP_BIN '^*'|awk {'print $4'}
+}
+
+function __get_current_kube_context_name {
+	kubes|$GREP_BIN '^*'|awk {'print $2'}
+}
 
 function __list_kube_context_names {
-	__list_kube_contexts|$GREP_BIN -v CURRENT|sed -e 's/^\*//'|awk {'print $1'}
+	kubes|$GREP_BIN -v CURRENT|sed -e 's/^\*//'|awk {'print $1'}
 }
 
 function __kube_context_compgen {
@@ -100,6 +127,7 @@ complete -F _kb_completion -o default kb;
 function kuse {
 	__kube_guard
 	unkubify
+	/bin/rm -f $_CURRENT_KUBE_CONTEXT_FILE
 	kubectl config use-context $1
 	kubify
 }
@@ -111,10 +139,10 @@ function kubify {
 	if [ "$?" != "0" ]; then
 		echo "can't access kubectl, is your PATH ok?"
 	fi
-	local __kube_cluster="`__list_kube_contexts |$GREP_BIN '^*'|awk {'print $3'}`"
-	local __kube_auth="`__list_kube_contexts |$GREP_BIN '^*'|awk {'print $4'}`"
-	local __kube_namespace="`__list_kube_contexts |$GREP_BIN '^*'|awk {'print $5'}`"
-	local __kube_context='`kubectl config current-context`'
+	local __kube_cluster='`__get_current_kube_context_cluster`'
+	local __kube_auth='`__get_current_kube_context_auth`'
+	local __kube_namespace='`__get_current_kube_context_namespace`'
+	local __kube_context='`__get_current_kube_context_name`'
 	local __prompt="(kb: $__kube_context"
 	if [ "$__kube_namespace" != "" ]; then
 		__prompt="$__prompt [$__kube_namespace]"


### PR DESCRIPTION
The previous implementation basically generated the values *once* for
everything except `kubectl config current-context` which was being
evaluated at every prompt.

This meant that with two shells open, the prompt could break like so:

Shell 1:
```
(kb: dev-eu-central-1 [dev]) ses: ~ $ kuse prod-eu-west-1
Switched to context "prod-eu-west-1".
(kb: prod-eu-west-1 [prod]) ses: ~ $
```

Shell 2:
```
(kb: dev-eu-central-1 [dev]) ses: ~ $
(kb: prod-eu-west-1 [dev]) ses: ~ $
```

The reported namespace (`[dev]`) is stale and wrong in shell 2, because
it's PS1 still has the namespace `prod` hardcoded as a string it's PS1.

These changes basically cause all the potential PS1 parts to be
generated by running bash functions which rely on the `kubes` command
which has now been refactored into a function which calls `kubectl
config get-contexts` only once per minute, and caches the output in
`/tmp`.  This is an optimization to reduce the cost of this dynamism.