### PR TITLE
Discover git repo when init-ing for context name, but allow a custom one

### DIFF
--- a/kyber/__init__.py
+++ b/kyber/__init__.py
@@ -58,15 +58,12 @@ def init_app():
     cwd = os.path.abspath('.')
 
     try:
-        repo = git.Repo(cwd)
-        suggested_name = init.get_default_name(repo)
+        repo = git.Repo.discover(cwd)
     except NotGitRepository:
-        try:
-            repo = git.Repo.discover(cwd)
-        except NotGitRepository:
-            click.echo("No repository found")
-            sys.exit(1)
-        suggested_name = cwd.split('/')[-1]
+        click.echo("No repository found")
+        sys.exit(1)
+
+    suggested_name = init.get_default_name(cwd)
 
     if suggested_name is None:
         click.echo("Unable to derive a name from the current git repository or directory!")

--- a/kyber/__init__.py
+++ b/kyber/__init__.py
@@ -32,16 +32,16 @@ def config_cli():
 @cli.command('deploy')
 @click.argument('tag', required=False)
 @click.option('--force', '-f', default=False, is_flag=True)
-@click.option('--no-prompt', 'prompt', default=True, is_flag=True)
+@click.option('--yes', '-y', default=False, is_flag=True)
 @context.required()
-def deploy_app(tag, force, prompt):
+def deploy_app(tag, force, yes):
     """ trigger a deployment """
     if tag is None:
         tag = context.tag
     if not tag.startswith('git_'):
         tag = 'git_{}'.format(tag)
 
-    if prompt:
+    if not yes:
         deployed_app = Environment(context.name).app
 
         click.echo("Project: {}".format(context.name))
@@ -49,7 +49,7 @@ def deploy_app(tag, force, prompt):
         click.echo("Deployed tag: {}".format(deployed_app.tag if deployed_app is not None else 'N/A'))
         click.echo("Tag to be deployed: {}".format(tag))
 
-        click.confirm("Continue?".format(tag, context.name), abort=True)
+        click.confirm("Continue?".format(tag, context.name), abort=True, default=True)
 
     app = App(context.name, context.docker, tag)
     if not ecr.image_exists(app.image):

--- a/kyber/__init__.py
+++ b/kyber/__init__.py
@@ -42,7 +42,14 @@ def deploy_app(tag, force, prompt):
         tag = 'git_{}'.format(tag)
 
     if prompt:
-        click.confirm("About to deploy {} to {}, continue?".format(tag, context.name), abort=True)
+        deployed_app = Environment(context.name).app
+
+        click.echo("Project: {}".format(context.name))
+        click.echo("Docker: {}".format(context.docker))
+        click.echo("Deployed tag: {}".format(deployed_app.tag if deployed_app is not None else 'N/A'))
+        click.echo("Tag to be deployed: {}".format(tag))
+
+        click.confirm("Continue?".format(tag, context.name), abort=True)
 
     app = App(context.name, context.docker, tag)
     if not ecr.image_exists(app.image):

--- a/kyber/context.py
+++ b/kyber/context.py
@@ -69,7 +69,8 @@ class Context(object):
     def git_status(self):
         from dulwich import porcelain as git
         try:
-            status = git.status()
+            repo = git.Repo.discover()
+            status = git.status(repo=repo)
         except dulwich.errors.NotGitRepository:
             raise ContextError("{} is not a valid git repository".format(self.cwd))
 
@@ -83,7 +84,7 @@ class Context(object):
 
     def git_tag(self):
         from dulwich import porcelain as git
-        repo = git.Repo(self.cwd)
+        repo = git.Repo.discover(self.cwd)
         self.tag = 'git_{}'.format(repo.head())
 
     def export(self):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,17 @@
+import mock
+
+from dulwich.errors import NotGitRepository
+
+from kyber.init import get_default_name
+
+
+def test_get_default_name_repo_name_if_repo_found():
+    mock_repo = mock.Mock()
+    mock_repo.get_config.return_value = {('remote', 'origin'): {'url': 'git@github.com:TakumiHQ/kyber.git'}}
+    with mock.patch('kyber.init.git.Repo', return_value=mock_repo):
+        assert get_default_name('/a/path/to/cool_repo') == 'kyber'
+
+
+def test_get_default_name_current_directory_if_no_repo_found():
+    with mock.patch('kyber.init.git.Repo', side_effect=NotGitRepository):
+        assert get_default_name('/a/path/to/cool_repo') == 'cool_repo'


### PR DESCRIPTION
During init, we check if the current directory is a git repo, if found, the suggested context name will be the git repo name.

If no repo is found, we try to discover a repo further down, since we need a repo for deployments. If none is found, raise error, else continue and suggest the current folder name as the context name.

I also added a quick prompt for `kb deploy`, so you would at least see what tag your are deploying to which project before it continues on.