### PR TITLE
Improved `kb status`

### DIFF
--- a/kyber/__init__.py
+++ b/kyber/__init__.py
@@ -41,10 +41,11 @@ def deploy_app(tag, force, yes):
         tag = context.tag
     if not tag.startswith('git_'):
         tag = 'git_{}'.format(tag)
+    context.tag = tag
 
     if not yes:
         status.echo(context)
-        click.confirm("Continue?".format(tag, context.name), abort=True, default=True)
+        click.confirm("Continue?", abort=True, default=True)
 
     app = App(context.name, context.docker, tag)
     if not ecr.image_exists(app.image):

--- a/kyber/__init__.py
+++ b/kyber/__init__.py
@@ -13,6 +13,7 @@ import config
 import context
 import init
 import shell
+import status
 
 # objects and helpers
 from objects import App, Environment
@@ -42,13 +43,7 @@ def deploy_app(tag, force, yes):
         tag = 'git_{}'.format(tag)
 
     if not yes:
-        deployed_app = Environment(context.name).app
-
-        click.echo("Project: {}".format(context.name))
-        click.echo("Docker: {}".format(context.docker))
-        click.echo("Deployed tag: {}".format(deployed_app.tag if deployed_app is not None else 'N/A'))
-        click.echo("Tag to be deployed: {}".format(tag))
-
+        status.echo(context)
         click.confirm("Continue?".format(tag, context.name), abort=True, default=True)
 
     app = App(context.name, context.docker, tag)
@@ -88,19 +83,7 @@ def init_app():
 @context.required()
 def get_status(skip_ecr, skip_k8s):
     """ get the remote (k8s and ecr) status for the current kyber app context """
-    app = App(context.name, context.docker, context.tag)
-
-    click.echo("Project: {}".format(context.name))
-    click.echo("Docker: {}".format(context.docker))
-    if not skip_k8s:
-        deployed_app = Environment(context.name).app
-        click.echo("Deployed tag: {}".format(deployed_app.tag if deployed_app is not None else 'N/A'))
-
-    deployable = '?'
-    if not skip_ecr:
-        deployable = 'y' if ecr.image_exists(app.image) else 'n'
-
-    click.echo("Current tag: {} [deployable: {}]".format(context.tag, deployable))
+    status.echo(context, skip_ecr, skip_k8s)
 
 
 @cli.command('completion')

--- a/kyber/context.py
+++ b/kyber/context.py
@@ -11,6 +11,7 @@ tag = None
 target = None
 dirty = None
 dirty_reason = None
+kube_ctx = None
 
 
 class ContextError(Exception):
@@ -62,6 +63,8 @@ class Context(object):
             raise ContextError(("No configuration found for kube context `{}` in kyber context."
                                 " Forgot to run 'kb init'?").format(kube_ctx))
 
+        self.kube_ctx = kube_api.config.contexts[kube_ctx]
+        self.kube_ctx['name'] = kube_ctx
         self.name = cfg[kube_ctx]['name']
         self.docker = cfg[kube_ctx]['docker']
         self.port = cfg[kube_ctx]['port']
@@ -88,13 +91,14 @@ class Context(object):
         self.tag = 'git_{}'.format(repo.head())
 
     def export(self):
-        global name, docker, tag, target, dirty, dirty_reason
+        global name, docker, tag, target, dirty, dirty_reason, kube_ctx
         name = self.name
         docker = self.docker
         tag = self.tag
         target = self.target
         dirty = self.git_dirty
         dirty_reason = self._git_status
+        kube_ctx = self.kube_ctx
 
 
 def required(**ctx_kwargs):
@@ -113,4 +117,4 @@ def required(**ctx_kwargs):
     return wrapper
 
 
-__all__ = [required, name, docker, tag, target, dirty, dirty_reason, Context]
+__all__ = [required, name, docker, tag, target, dirty, dirty_reason, kube_ctx, Context]

--- a/kyber/status.py
+++ b/kyber/status.py
@@ -3,7 +3,7 @@ import click
 from objects import App, Environment
 from lib import ecr
 
-def echo(context, skip_k8s, skip_ecr):
+def echo(context, skip_k8s=False, skip_ecr=False):
     """ get the remote (k8s and ecr) status for the current kyber app context """
     app = App(context.name, context.docker, context.tag)
 

--- a/kyber/status.py
+++ b/kyber/status.py
@@ -1,0 +1,21 @@
+import click
+
+from objects import App, Environment
+from lib import ecr
+
+def echo(context, skip_k8s, skip_ecr):
+    """ get the remote (k8s and ecr) status for the current kyber app context """
+    app = App(context.name, context.docker, context.tag)
+
+    click.echo("Project: {}".format(context.name))
+    click.echo("Docker: {}".format(context.docker))
+    if not skip_k8s:
+        deployed_app = Environment(context.name).app
+        click.echo("Deployed tag: {}".format(deployed_app.tag if deployed_app is not None else 'N/A'))
+
+    deployable = '?'
+    if not skip_ecr:
+        deployable = 'y' if ecr.image_exists(app.image) else 'n'
+
+    click.echo("Current tag: {} [deployable: {}]".format(context.tag, deployable))
+    click.echo("Kubernetes target: {} ({})".format(context.kube_ctx['cluster'], context.kube_ctx['namespace']))


### PR DESCRIPTION
Refactor status command + add kubernetes target (context) to status, and re-use status method for deployment status.

```
(venv) ses: ~/w/takumi-server 26:* master$ kb status
Project: takumi-server
Docker: 575449495505.dkr.ecr.us-east-1.amazonaws.com/takumi-server
Deployed tag: git_fa6c5f65ef7fa1b27b37741f36601ecfc4bb758f
Current tag: git_5da791a5929ee78078f30026c8a68214cb37d49b [deployable: y]
Kubernetes target: eu-west-1.kube.takumi.com (prod)
```
This fixes #20 and #21