### PR TITLE
Return immediately if waiting for no deployments

### DIFF
--- a/kyber/deploy.py
+++ b/kyber/deploy.py
@@ -43,6 +43,9 @@ def execute(app, force=False):
 
 
 def wait_for(deployments):
+    if deployments is None or len(deployments) is 0:
+        return
+
     for event in Deployment.objects(kube_api).filter(namespace=kube_api.config.namespace).watch():
         if event.type != 'MODIFIED':
             continue


### PR DESCRIPTION
In the case of having nothing to wait for (for example, if you try to deploy an already deployed tag without `--force`), we should just return immediately.