### PR TITLE
Avoid crash when initializing new app environment

### DIFF
--- a/kyber/objects/environment.py
+++ b/kyber/objects/environment.py
@@ -45,12 +45,13 @@ class Environment(object):
 
     def _get_linked_deployments(self):
         linked = []
-        for key in self.deployment.annotations.keys():
-            if key.startswith(LINKED_DEPLOYMENT_KEY_PREFIX):
-                deployment = Deployment.objects(kube_api).get(
-                    name=self.deployment.annotations[key]
-                )
-                linked.append(deployment)
+        if self.deployment is not None:
+            for key in self.deployment.annotations.keys():
+                if key.startswith(LINKED_DEPLOYMENT_KEY_PREFIX):
+                    deployment = Deployment.objects(kube_api).get(
+                        name=self.deployment.annotations[key]
+                    )
+                    linked.append(deployment)
         return linked
 
     def status(self):


### PR DESCRIPTION
Before the environment loading would crash if no deployment existed:

```
$ kb init
Enter environment name [takumi-server]: takumi-server-preflight
Loading environment for takumi-server-preflight from
preflight-eu-central-1
Traceback (most recent call last):
  File "/usr/local/bin/kb", line 11, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 722,
in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 697,
in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line
1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 895,
in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 535,
in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/kyber/__init__.py", line
76, in init_app
    init.initialize(name, repo.head())
  File "/usr/local/lib/python2.7/site-packages/kyber/init.py", line 97,
in initialize
    environment = Environment(name)
  File
"/usr/local/lib/python2.7/site-packages/kyber/objects/environment.py",
line 44, in __init__
    self.linked_deployments = self._get_linked_deployments()
  File
"/usr/local/lib/python2.7/site-packages/kyber/objects/environment.py",
line 48, in _get_linked_deployments
    for key in self.deployment.annotations.keys():
```