### PR TITLE
Add some vars to the shell environment. 

### DIFF
--- a/kyber/shell.py
+++ b/kyber/shell.py
@@ -1,15 +1,32 @@
 import click
 import os
+import pwd
 from pykube.objects import Pod
 from kyber.lib.kube import kube_api
 from kyber.utils import get_executable_path
 
 
-def run(name, shell_path):
+
+
+def run(name, shell):
     for pod in Pod.objects(kube_api).filter(selector={'app': name}).iterator():
         if pod.ready:  # use the first ready pod, otherwise we use the last pod
             break
 
+    def env_vars():
+        d = {
+            'KYBER_USER': pwd.getpwuid(os.getuid()).pw_name,
+            'KYBER_POD': pod.name,
+            'KYBER_APP': name
+        }
+        return " ".join(["{}={}".format(key, val) for key, val in d.iteritems()])
+
+    cmd = '{env} {shell}'.format(env=env_vars(), shell=shell)
+
     click.echo("Running shell in pod `{}` in kube ctx `{}`".format(
                pod.name, kube_api.config.current_context))
-    os.execve(get_executable_path('kubectl'), ["kubectl", "exec", "-i", "-t", pod.name, shell_path], os.environ)
+    os.execve(
+        get_executable_path('kubectl'),
+        ["kubectl", "exec", "-i", "-t", pod.name, '--', shell, '-c', cmd],
+        os.environ
+    )

--- a/kyber/shell.py
+++ b/kyber/shell.py
@@ -17,7 +17,8 @@ def run(name, shell):
         d = {
             'KYBER_USER': pwd.getpwuid(os.getuid()).pw_name,
             'KYBER_POD': pod.name,
-            'KYBER_APP': name
+            'KYBER_APP': name,
+            'KYBER_KUBECTL_CONTEXT': kube_api.config.current_context,
         }
         return " ".join(["{}={}".format(key, val) for key, val in d.iteritems()])
 


### PR DESCRIPTION
Add the following environment variables to a kyber shell by prepending them to the shell command:

- `KYBER_USER` = your username on your local machine (should match `whoami`)
- `KYBER_POD` = the pod which the command was intended to execute on, it should match the hostname on the pod
- `KYBER_APP` = the kyber app in which `kb shell` was invoked
- `KYBER_KUBECTL_CONTEXT` = the name of the current kubectl context (which kyber is using to execute the shell)

This was tested with /bin/sh on an alpine linux docker and /bin/bash on an ubuntu docker.

Example:
```
$ kb shell
Running shell in pod `takumi-server-880325575-9m30r` in kube ctx `dev-eu-central-1`
(venv) root@takumi-server-880325575-9m30r:~# env|grep KYBER
KYBER_APP=takumi-server
KYBER_USER=ses
KYBER_POD=takumi-server-880325575-9m30r
KYBER_KUBECTL_CONTEXT=dev-eu-central-1
```