### PR TITLE
Use kubectl proxy and token for kb dash

### DIFF
--- a/kyber/dash.py
+++ b/kyber/dash.py
@@ -1,5 +1,4 @@
 import json
-import os
 import subprocess
 from urlparse import urljoin
 
@@ -49,7 +48,7 @@ def launch(cfg=None, executor=None):  # noqa: C901
         cfg = kube_api.config
 
     if executor is None:
-        executor = os.execve
+        executor = subprocess
 
     token = _get_token(cfg)
     if token:
@@ -57,7 +56,7 @@ def launch(cfg=None, executor=None):  # noqa: C901
 
     click.echo("Starting kubectl proxy")
     try:
-        proxy = subprocess.Popen(["kubectl", "proxy"])
+        proxy = executor.Popen(["kubectl", "proxy"])
     except Exception as e:
         click.echo("Unable to start kubectl proxy ({})".format(e))
         proxy = None
@@ -77,7 +76,7 @@ def launch(cfg=None, executor=None):  # noqa: C901
         url = namespace_dashboard(cfg)
 
     try:
-        subprocess.call(["open", url])
+        executor.call(["open", url])
     except Exception as e:
         click.echo("Unable to launch dashboard automatically ({})".format(e))
         click.echo("URL: {}".format(url))

--- a/kyber/dash.py
+++ b/kyber/dash.py
@@ -1,52 +1,86 @@
-import click
+import json
 import os
-from urlparse import urlparse, urlunparse
+import subprocess
+from urlparse import urljoin
+
+import click
 
 from kyber.context import Context, ContextError
-from kyber.utils import get_executable_path
-
-
-def _kube_dash_base_url(cfg):
-    url = urlparse(cfg.cluster['server'])
-    try:
-        username = cfg.user['username']
-        password = cfg.user['password']
-        url = url._replace(netloc='{}:{}@{}'.format(username, password, url.netloc))
-    except KeyError:  # no username/pass in kube context?
-        pass
-    return url
 
 
 def service_dashboard(cfg, name):
-    path = ("/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/"
-            "#/service/{namespace}/{app_name}?namespace={namespace}").format(
-                namespace=cfg.namespace, app_name=name)
-    return urlunparse(_kube_dash_base_url(cfg)._replace(path=path))
+    path = (
+        "/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:"
+        "/proxy/#!/service/{namespace}/{app_name}?namespace={namespace}"
+    ).format(namespace=cfg.namespace, app_name=name)
+    return urljoin("http://localhost:8001", path)
 
 
 def namespace_dashboard(cfg):
-    path = ("/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/"
-            "#/pod?namespace={namespace}").format(namespace=cfg.namespace)
-    return urlunparse(_kube_dash_base_url(cfg)._replace(path=path))
+    path = (
+        "/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:"
+        "/proxy/#!/overview?namespace={namespace}"
+    ).format(namespace=cfg.namespace)
+    return urljoin("http://localhost:8001", path)
 
 
-def launch(cfg=None, executor=None):
+def _get_token(cfg):
+    user = cfg.user
+    if "exec" not in user:
+        return
+
+    args = user["exec"]["args"]
+    args.insert(0, user["exec"]["command"])
+
+    try:
+        response = subprocess.check_output(args)
+        parsed = json.loads(response)
+    except Exception as e:
+        click.echo("Unable to get token ({})".format(e))
+        return
+
+    return parsed.get("status", {}).get("token")
+
+
+def launch(cfg=None, executor=None):  # noqa: C901
     if cfg is None:
         from kyber.lib.kube import kube_api
+
         cfg = kube_api.config
+
     if executor is None:
         executor = os.execve
 
+    token = _get_token(cfg)
+    if token:
+        click.echo("Your login token:\n\n{}\n".format(token))
+
+    click.echo("Starting kubectl proxy")
+    try:
+        proxy = subprocess.Popen(["kubectl", "proxy"])
+    except Exception as e:
+        click.echo("Unable to start kubectl proxy ({})".format(e))
+        proxy = None
+
     try:
         context = Context()
-        click.echo("Opening dashboard for `{}` in `{}`".format(context.name, cfg.namespace))
+        click.echo(
+            "Opening dashboard for `{}` in `{}`".format(context.name, cfg.namespace)
+        )
         url = service_dashboard(cfg, context.name)
     except ContextError:  # fall back to opening the kubernetes dashboard
-        click.echo("Not in a kyber context, showing dash for k8s pods in `{}`".format(cfg.namespace))
+        click.echo(
+            "Not in a kyber context, showing dash for k8s pods in `{}`".format(
+                cfg.namespace
+            )
+        )
         url = namespace_dashboard(cfg)
 
     try:
-        executor(get_executable_path('open'), ["open", url], os.environ)
+        subprocess.call(["open", url])
     except Exception as e:
-        click.echo("Unable to launch dashboard automatically ({})".format(e.message))
+        click.echo("Unable to launch dashboard automatically ({})".format(e))
         click.echo("URL: {}".format(url))
+
+    if proxy is not None:
+        proxy.wait()

--- a/tests/test_dash.py
+++ b/tests/test_dash.py
@@ -2,28 +2,16 @@ import mock
 from collections import namedtuple
 
 from kyber.context import ContextError
-from kyber.dash import launch, _kube_dash_base_url
+from kyber.dash import launch
 
 
 KubeConfig = namedtuple('KubeConfig', 'cluster user')
 
 
-def test_kube_dash_base_url_adds_auth_if_found():
-    cfg = KubeConfig(cluster=dict(server='https://test'), user=dict(username='mocky', password='python'))
-    url = _kube_dash_base_url(cfg)
-    assert url.netloc == 'mocky:python@test'
-
-
-def test_kube_dash_base_url_adds_no_auth_if_not_found():
-    cfg = KubeConfig(cluster=dict(server='https://test'), user=dict())
-    url = _kube_dash_base_url(cfg)
-    assert url.netloc == 'test'
-
-
 def test_launch_calls_service_dashboard():
     with mock.patch('kyber.dash.Context'):
         with mock.patch('kyber.dash.service_dashboard') as mock_service_dashboard:
-            launch(cfg=mock.Mock(), executor=mock.Mock())
+            launch(cfg=mock.MagicMock(), executor=mock.Mock())
             assert mock_service_dashboard.called
 
 
@@ -32,19 +20,6 @@ def test_launch_calls_namespace_dashboard_if_context_error():
         mock_context.side_effect = ContextError('meh')
         with mock.patch('kyber.dash.service_dashboard') as mock_service_dashboard:
             with mock.patch('kyber.dash.namespace_dashboard') as mock_namespace_dashboard:
-                launch(cfg=mock.Mock(), executor=mock.Mock())
+                launch(cfg=mock.MagicMock(), executor=mock.Mock())
                 assert not mock_service_dashboard.called
                 assert mock_namespace_dashboard.called
-
-
-def test_launch_echos_url_if_executor_not_found():
-    with mock.patch('kyber.dash.Context'):
-        with mock.patch('kyber.dash.service_dashboard'):
-            with mock.patch('kyber.dash.namespace_dashboard'):
-                with mock.patch('kyber.dash.click') as mock_click:
-                    mock_exec = mock.Mock(side_effect=Exception('mocky pythons holy exception'))
-                    launch(cfg=mock.Mock(), executor=mock_exec)
-                    assert mock_exec.called
-                    assert mock_click.echo.called
-                    assert 'mocky pythons holy exception' in mock_click.echo.call_args_list[1][0][0]
-                    assert 'URL: ' in mock_click.echo.call_args_list[2][0][0]


### PR DESCRIPTION
Tries to get the token with the command + arguments specified in the config and prints it out for the user. `kubectl proxy` is then started in the background before trying to open the url to the dashboard.

```
Your login token:

k8s-aws-v1.<redacted token>

Starting kubectl proxy
Not in a kyber context, showing dash for k8s pods in `default`
Starting to serve on 127.0.0.1:8001
^C
Aborted!
```